### PR TITLE
mountservice: Shut down volumes before restarting framework

### DIFF
--- a/services/core/java/com/android/server/MountService.java
+++ b/services/core/java/com/android/server/MountService.java
@@ -2393,6 +2393,7 @@ class MountService extends IMountService.Stub
                 mHandler.postDelayed(new Runnable() {
                     public void run() {
                         try {
+                            mConnector.execute("volume", "shutdown");
                             mCryptConnector.execute("cryptfs", "restart");
                         } catch (NativeDaemonConnectorException e) {
                             Slog.e(TAG, "problem executing in background", e);


### PR DESCRIPTION
 * Vold assumes that when FUSE is killed, the mount is gone. This
   isn't true with sdcardfs, since the daemon doesn't continue
   to run. Cryptfs was assuming this behavior, and the system would
   hang during decryption since the emulated storage doesn't get
   unmounted.
 * Send the shutdown command before committing suicide.

Change-Id: Ifcfa63f0499a717f34482754cea95b90622290c6